### PR TITLE
Fix Debug symbols building

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -135,7 +135,8 @@ jobs:
   
       - name: Cache SCons cache 
         uses: actions/cache@v4 
-        if: always() 
+        # Skip cache on Linux, PR #12
+        if: ${{ matrix.platform != 'linuxbsd' }}
         with: 
           path: | 
             .scons_cache  
@@ -198,17 +199,24 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     needs: ["build", "build-native"]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linuxbsd, windows, macos, android, web]
     steps:
       - name: Merge Artifacts
         uses: actions/upload-artifact/merge@v4
         with:
-          name: v-sekai-world
+          name: v-sekai-world-${{ matrix.platform }}
+          pattern: "*${{ matrix.platform }}*"
           delete-merged: true
 
   release:
     runs-on: ubuntu-latest
     needs: merge
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Create Release
         id: create_release
@@ -221,23 +229,31 @@ jobs:
           draft: false
           prerelease: true
 
+  upload-releases:
+    runs-on: ubuntu-latest
+    needs: release
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linuxbsd, windows, macos, android, web]
+    steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
-          path: v-sekai-world
-          name: v-sekai-world
+          path: v-sekai-world-${{ matrix.platform }}
+          name: v-sekai-world-${{ matrix.platform }}
 
       - name: Zip Artifacts
         run: |
           tree
-          zip -r v-sekai-world.zip v-sekai-world
+          zip -r v-sekai-world-${{ matrix.platform }}.zip v-sekai-world-${{ matrix.platform }}
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./v-sekai-world.zip
-          asset_name: v-sekai-world.zip
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ./v-sekai-world-${{ matrix.platform }}.zip
+          asset_name: v-sekai-world-${{ matrix.platform }}.zip
           asset_content_type: application/zip

--- a/Justfile
+++ b/Justfile
@@ -171,7 +171,8 @@ build-platform-target platform target precision="double":
                     vulkan_sdk_path=$VULKAN_SDK_ROOT/MoltenVK/MoltenVK/static/MoltenVK.xcframework \
                     osxcross_sdk=darwin24 \
                     generate_bundle=yes \
-                    debug_symbol=yes
+                    debug_symbols=yes \
+                    separate_debug_symbols=yes
             ;;
         windows)
             scons platform=windows \
@@ -182,7 +183,8 @@ build-platform-target platform target precision="double":
                 test=yes \
                 use_llvm=yes \
                 use_mingw=yes \
-                debug_symbols=yes
+                debug_symbols=yes \
+                separate_debug_symbols=yes
             ;;
         android)
             scons platform=android \
@@ -191,7 +193,7 @@ build-platform-target platform target precision="double":
                     precision={{precision}} \
                     target={{target}} \
                     test=yes \
-                    debug_symbol=yes
+                    #debug_symbols=yes    # Editor build runs out of space in Github Runner
             ;;
         linuxbsd)
             scons platform=linuxbsd \
@@ -200,7 +202,8 @@ build-platform-target platform target precision="double":
                     precision={{precision}} \
                     target={{target}} \
                     test=yes \
-                    debug_symbol=yes
+                    debug_symbols=yes \
+                    separate_debug_symbols=yes
             ;;
         web)
             scons platform=web \
@@ -210,7 +213,7 @@ build-platform-target platform target precision="double":
                     target={{target}} \
                     test=yes \
                     dlink_enabled=yes \
-                    debug_symbol=yes
+                    debug_symbols=yes
             ;;
         *)
             echo "Unsupported platform: {{platform}}"


### PR DESCRIPTION
Some typos made **Debug symbols** only available on `windows`. This issue was fixed.
**Github Actions** limits releases to **2 Gb** per file, so release archives are now **split by platform**.
`Android` build **runs out of space** when symbols are enabled, so I disabled them. This needs some investigation.

I tested without `build` job scons cache, if space runs out it could be removed.