### PR TITLE
Split export templates release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -196,9 +196,48 @@ jobs:
           name: Godot-${{ matrix.platform }}-${{ matrix.target }}-${{ matrix.precision }}
           path: editor
 
-  merge:
+  merge-templates:
     runs-on: ubuntu-latest
     needs: ["build", "build-native"]
+    steps:
+      - name: Merge Export Templates
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: v-sekai-godot-templates-all
+          pattern: "*.tpz"
+          delete-merged: true
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: v-sekai-godot-templates
+          name: v-sekai-godot-templates-all
+
+      - name: Split Export Templates Symbols
+        run: | 
+          mkdir -p v-sekai-godot-templates-symbols
+
+          # Suppress if null glob error
+          mv v-sekai-godot-templates/*.pdb v-sekai-godot-templates-symbols/ || true
+          mv v-sekai-godot-templates/*.debugsymbols v-sekai-godot-templates-symbols/ || true
+          mv v-sekai-godot-templates/*.dSYM v-sekai-godot-templates-symbols/ || true
+          tree
+
+      - name: Upload Export Templates
+        uses: actions/upload-artifact@v4
+        with:
+          name: v-sekai-godot-templates
+          path: v-sekai-godot-templates
+
+      - name: Upload Export Templates Symbols
+        uses: actions/upload-artifact@v4
+        with:
+          name: v-sekai-godot-templates-symbols
+          path: v-sekai-godot-templates-symbols
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: merge-templates
     strategy:
       fail-fast: false
       matrix:
@@ -228,6 +267,35 @@ jobs:
           release_name: Latest Release of V-Sekai Godot Engine Editor
           draft: false
           prerelease: true
+
+  upload-templates:
+    runs-on: ubuntu-latest
+    needs: release
+    strategy:
+      fail-fast: false
+      matrix:
+        type: [templates, templates-symbols]
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: v-sekai-godot-${{ matrix.type }}
+          name: v-sekai-godot-${{ matrix.type }}
+
+      - name: Zip Artifacts
+        run: |
+          tree
+          zip -r v-sekai-godot-${{ matrix.type }}.zip v-sekai-godot-${{ matrix.type }}
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ./v-sekai-godot-${{ matrix.type }}.zip
+          asset_name: v-sekai-godot-${{ matrix.type }}.zip
+          asset_content_type: application/zip
 
   upload-releases:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Split all templates in a different release file. Debug symbols are split from binaries to avoid 2Gb upload limit error.