### PR TITLE
Package templates in TPZ format

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -273,7 +273,8 @@ jobs:
           prerelease: true
 
   upload-templates:
-    runs-on: ubuntu-latest
+    # 'just' is apt package from 24.04+
+    runs-on: ubuntu-24.04
     needs: release
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -286,6 +287,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
+            Justfile
+            godot/version.py
             .github/zip-upload-split/action.yml
 
       - name: Download Artifacts
@@ -294,15 +297,23 @@ jobs:
           path: v-sekai-godot-${{ matrix.type }}
           name: v-sekai-godot-${{ matrix.type }}
 
-      - name: Zip Artifacts
+      - name: Pack Artifacts
+        id: pack
         run: |
           tree
-          zip -rm v-sekai-godot-${{ matrix.type }}.zip v-sekai-godot-${{ matrix.type }}
+          if ${{ matrix.type == 'templates' }}; then \
+            sudo apt install -y just; \
+            just package-tpz v-sekai-godot-${{ matrix.type }} v-sekai-godot-${{ matrix.type }} ./godot/version.py; \
+            zip -0 -rm v-sekai-godot-${{ matrix.type }}.zip v-sekai-godot-${{ matrix.type }}.tpz; \
+          else \
+            zip -rm v-sekai-godot-${{ matrix.type }}.zip v-sekai-godot-${{ matrix.type }}; \
+          fi
+          echo "name=v-sekai-godot-${{ matrix.type }}.zip" >> ${GITHUB_OUTPUT}
 
       - name: Upload Zip Release Asset
         uses: ./.github/zip-upload-split
         with:
-          zip-path: ./v-sekai-godot-${{ matrix.type }}.zip
+          zip-path: ./${{ steps.pack.outputs.name }}
           release-id: ${{ needs.release.outputs.id }}
           token: ${GITHUB_TOKEN}
 

--- a/Justfile
+++ b/Justfile
@@ -278,3 +278,25 @@ handle-android target:
         cd ../../..
         ls -l bin/
     fi
+
+package-tpz folder tpzname versionpy:
+    #!/usr/bin/env bash
+    cd {{folder}}
+    for file in *; do \
+        filename=$( echo ${file} \
+          | sed 's/\(godot.\|.double\|.template\|.llvm\|.wasm32\)//g' \
+          | sed 's/linuxbsd/linux/;s/.console/_console/' \
+          | sed 's/^web\(_debug\|_release\)\.\(dlink\)\(.*\)/web_\2\1\3/' \
+          | sed 's/\(windows_[a-z]*\)\./\1_/' \
+        ) \
+        && echo -e "Renaming ${file} to \n ${filename}" \
+        && mv ${file} ${filename}
+    done
+    cd ..
+    cat {{versionpy}} | tr -d ' ' | tr -s '\n' ' ' \
+      | sed -E 's/.*major=([0-9]).minor=([0-9]).*status=\"([a-z]*)\".*/\1.\2.\3/' \
+      > {{folder}}/version.txt
+    echo "Godot TPZ Version: $( cat {{folder}}/version.txt )"
+    mkdir -p tpz_temp && mv {{folder}} tpz_temp/templates && cd tpz_temp \
+      && zip -r ../{{tpzname}}.tpz templates && cd ..
+    rm -r tpz_temp


### PR DESCRIPTION
#19 
Package export templates.
Names are mapped via `sed` instead of a mapping file. This should allow flexibility if names are changed by different compiler options.

These files are missing from our template file compared to Godot
```
templates/ios.zip
templates/linux_debug.arm32
templates/linux_debug.arm64
templates/linux_debug.x86_32
templates/linux_release.arm32
templates/linux_release.arm64
templates/linux_release.x86_32
templates/web_debug.zip
templates/web_dlink_nothreads_debug.zip
templates/web_dlink_nothreads_release.zip
templates/web_nothreads_debug.zip
templates/web_nothreads_release.zip
templates/web_release.zip
templates/windows_debug_arm64_console.exe
templates/windows_debug_arm64.exe
templates/windows_debug_x86_32_console.exe
templates/windows_debug_x86_32.exe
templates/windows_release_arm64_console.exe
templates/windows_release_arm64.exe
templates/windows_release_x86_32_console.exe
templates/windows_release_x86_32.exe
```

Our template file has these additional files (after `sed` naming). They could be build files.
```
templates/godot-lib_debug.aar
templates/godot-lib_release.aar
templates/macos_debug.arm64
templates/macos_release.arm64
templates/side.web_debug.dlink.wasm
templates/side.web_release.dlink.wasm
templates/web_dlink_debug.engine.js
templates/web_dlink_debug.js
templates/web_dlink_debug.wasm
templates/web_dlink_debug.worker.js
templates/web_dlink_debug.wrapped.js
templates/web_dlink_release.engine.js
templates/web_dlink_release.js
templates/web_dlink_release.wasm
templates/web_dlink_release.worker.js
templates/web_dlink_release.wrapped.js
```
And a `templates/` entry in zip index.

Importing in editor is not tested.