### PR TITLE
Fix templates not split from editor release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -250,7 +250,7 @@ jobs:
         uses: actions/upload-artifact/merge@v4
         with:
           name: v-sekai-godot-${{ matrix.platform }}
-          pattern: "*${{ matrix.platform }}*"
+          pattern: "*${{ matrix.platform }}-editor*"
           delete-merged: true
 
   release:


### PR DESCRIPTION
There are templates inside editor zips. This PR fixes it.