### PR TITLE
Add 7z split zip support

### DIFF
--- a/.github/zip-upload-split/action.yml
+++ b/.github/zip-upload-split/action.yml
@@ -12,6 +12,10 @@ inputs:
   token:
     description: 'Github Token'
     required: true
+  zip-cmd:
+    description: 'Select zipping software ( "7zip", "zip" )'
+    required: false
+    default: '7zip'
 
 runs:
   using: "composite"
@@ -20,11 +24,44 @@ runs:
       shell: bash
       env:
         # Github upload limit is less than stated 2147483648 bytes (2147483k).
-        MAX_SIZE: 2050000
+        MAX_SIZE: 2050000000
+        MAX_SIZE_K: 2050000
+        SHA256_7ZIP: 'cb5e49caaf761df67add54729553bef89a38071b0c455461452578018625fee5'
       run: |
-          mkdir _temp
           NAME=$( basename ${{ inputs.zip-path }} )
-          zip ${{ inputs.zip-path }} --out _temp/${NAME} -s "${MAX_SIZE}k"
+          SIZE=$( stat -c %s ${{ inputs.zip-path }} )
+
+          mkdir _temp
+          if [ "${SIZE}" -le "${MAX_SIZE}" ]; then
+            cp ${{ inputs.zip-path }} _temp/${NAME};
+          elif [ ${{ inputs.zip-cmd }} == '7zip' ]; then
+
+            # On ubuntu-22.04 and ubuntu-24.04 apt package has a bug
+            # https://sourceforge.net/p/sevenzip/bugs/2407/
+            # sudo apt install -y 7zip;
+
+            # Checksum
+            curl -O "https://www.7-zip.org/a/7z2409-linux-x86.tar.xz";
+            if ! echo "${SHA256_7ZIP} 7z2409-linux-x86.tar.xz" | sha256sum -c ; then
+              echo "Incorrect 7zip package SHA256 checksum. Downloading from mirror..." >&2;
+              rm 7z2409-linux-x86.tar.xz;
+
+              curl -OL "https://github.com/ip7z/7zip/releases/download/24.09/7z2409-linux-x86.tar.xz";
+              if ! echo "${SHA256_7ZIP} 7z2409-linux-x86.tar.xz" | sha256sum -c ; then
+                echo "7zip package SHA256 check failed." >&2;
+                exit 1;
+              fi
+            fi
+
+            tar -xvf 7z2409-linux-x86.tar.xz "7zz";
+            chmod +x 7zz;
+            ./7zz a -tzip -v${MAX_SIZE_K}k _temp/${NAME} ${{ inputs.zip-path }};
+            rm 7z2409-linux-x86.tar.xz 7zz
+          else
+            # unknown zip bug can corrupt files in split archives 
+            zip ${{ inputs.zip-path }} --out _temp/${NAME} -s "${MAX_SIZE_K}k";
+          fi
+
           tree
           cd _temp
           for file in *; do \


### PR DESCRIPTION
Splitting files with 'zip' corrupts _'android_source.zip'_  file in _'v-sekai-godot-templates.zip'._ [Release latest.v-sekai-editor-80](https://github.com/V-Sekai/world-godot/releases/tag/latest.v-sekai-editor-80).
This PR changes zipping software to 7zip.