### PR TITLE
Fix missing mac and ios release templates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         precision: [double]
         platform: [macos, ios]
-        target: [editor, template_release, template_debug]
+        target: [editor, templates]
         exclude:
           - platform: ios
             target: editor
@@ -72,7 +72,11 @@ jobs:
       - name: Fetch dependencies and Build Platform Target 
         run: | 
           export PLATFORM_ARGS="fetch-vulkan-sdk"
-          hyperfine --show-output --runs 1 'just $PLATFORM_ARGS && just build-platform-target ${{ matrix.platform }} ${{ matrix.target }} ${{ matrix.precision }}'
+          if [ ${{ matrix.target }} == "templates" ]; then
+            hyperfine --show-output --runs 1 'just $PLATFORM_ARGS && just build-platform-templates ${{ matrix.platform }} ${{ matrix.precision }}'
+          else
+            hyperfine --show-output --runs 1 'just $PLATFORM_ARGS && just build-platform-target ${{ matrix.platform }} ${{ matrix.target }} ${{ matrix.precision }}'
+          fi
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/Justfile
+++ b/Justfile
@@ -147,7 +147,7 @@ generate_build_constants:
     echo "const BUILD_DATE_STR = \"$(shell date --utc --iso=seconds)\"" >> v/addons/vsk_version/build_constants.gd
     echo "const BUILD_UNIX_TIME = $(shell date +%s)" >> v/addons/vsk_version/build_constants.gd
 
-build-platform-target platform target precision="double":
+build-platform-target platform target precision="double" osx_bundle="yes":
     #!/usr/bin/env bash
     set -o xtrace
     cd $WORLD_PWD
@@ -170,7 +170,7 @@ build-platform-target platform target precision="double":
                     arch=arm64 \
                     vulkan_sdk_path=$VULKAN_SDK_ROOT/MoltenVK/MoltenVK/static/MoltenVK.xcframework \
                     osxcross_sdk=darwin24 \
-                    generate_bundle=yes \
+                    generate_bundle={{osx_bundle}} \
                     debug_symbols=yes \
                     separate_debug_symbols=yes
             ;;
@@ -231,7 +231,7 @@ build-platform-target platform target precision="double":
                     arch=arm64 \
                     vulkan_sdk_path=$VULKAN_SDK_ROOT/MoltenVK/MoltenVK/static/MoltenVK.xcframework \
                     osxcross_sdk=darwin24 \
-                    generate_bundle=yes \
+                    generate_bundle={{osx_bundle}} \
                     debug_symbols=yes \
                     separate_debug_symbols=yes
             ;;
@@ -244,10 +244,20 @@ build-platform-target platform target precision="double":
     if [[ "{{target}}" == "editor" ]]; then
         mkdir -p $WORLD_PWD/editors
         cp -rf $WORLD_PWD/godot/bin/* $WORLD_PWD/editors
+    elif [[ "{{target}}" =~ template_* && \
+            "{{platform}}" =~ ^(mac|i)os && \
+            "{{osx_bundle}}" == "no" ]]; then
+        # don't copy files to $WORLD_PWD/tpz
+        true
     elif [[ "{{target}}" =~ template_* ]]; then
         mkdir -p $WORLD_PWD/tpz
         cp -rf $WORLD_PWD/godot/bin/* $WORLD_PWD/tpz
     fi
+
+build-platform-templates platform precision="double":
+    # Bundle all on last command with osx_bundle
+    just build-platform-target {{platform}} template_debug {{precision}} "no"
+    just build-platform-target {{platform}} template_release {{precision}} "yes"
 
 all-build-platform-target:
     #!/usr/bin/env bash


### PR DESCRIPTION
Release templates were overwritten in Github Action by debug templates "macos.zip".
In order to generate a correct _macos.zip_ we have to build with _generate_bundle_ option on **last** template build only.

[Source - Godot Docs](https://docs.godotengine.org/en/stable/contributing/development/compiling/compiling_for_macos.html#building-export-templates)
`This process can be automated by using the generate_bundle=yes option on the last SCons command used to build export templates (so that all binaries can be included). `