### PR TITLE
Fix mac build architecture

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -186,7 +186,6 @@ build-platform-target platform target arch="auto" precision="double" osx_bundle=
                     target={{target}} \
                     test=yes \
                     vulkan=no \
-                    arch=arm64 \
                     vulkan_sdk_path=$VULKAN_SDK_ROOT/MoltenVK/MoltenVK/static/MoltenVK.xcframework \
                     osxcross_sdk=darwin24 \
                     generate_bundle={{osx_bundle}} \
@@ -252,7 +251,6 @@ build-platform-target platform target arch="auto" precision="double" osx_bundle=
                     target={{target}} \
                     test=yes \
                     vulkan=no \
-                    arch=arm64 \
                     vulkan_sdk_path=$VULKAN_SDK_ROOT/MoltenVK/MoltenVK/static/MoltenVK.xcframework \
                     osxcross_sdk=darwin24 \
                     generate_bundle={{osx_bundle}} \


### PR DESCRIPTION
#37
Githu runner macos-latest (macos 14) is arm64 so we don't need to pass arch argument in 'build-native' job.