### PR TITLE
Fix web template_debug Github build error

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -188,12 +188,16 @@ jobs:
         run: | 
           just install_packages 
           export PLATFORM_ARGS=""
+          export EXTRA_OPTIONS=""
           case "${{ matrix.platform }}" in  
             android)  
               PLATFORM_ARGS="fetch-openjdk setup-android-sdk"  
               ;;  
             web)  
-              PLATFORM_ARGS="setup-emscripten"  
+              PLATFORM_ARGS="setup-emscripten"
+              if [ ${{ matrix.target }} == 'template_debug' ]; then
+                  EXTRA_OPTIONS="optimize=none"; # Fix Github runner out of RAM
+              fi
               ;;  
             windows)  
               PLATFORM_ARGS="fetch-llvm-mingw"  
@@ -208,7 +212,7 @@ jobs:
           if "${{ matrix.architecture == 'arm64' }}"; then
               PLATFORM_ARGS="setup-arm64 $PLATFORM_ARGS"
           fi
-          hyperfine --show-output --runs 1 'just $PLATFORM_ARGS && just build-platform-target ${{ matrix.platform }} ${{ matrix.target }} ${{ matrix.architecture }} ${{ matrix.precision }}'
+          hyperfine --show-output --runs 1 'just $PLATFORM_ARGS && just build-platform-target ${{ matrix.platform }} ${{ matrix.target }} ${{ matrix.architecture }} ${{ matrix.precision }} yes $EXTRA_OPTIONS'
 
       - name: Upload Android Editors
         if: ${{ matrix.platform == 'android' && matrix.target == 'editor' }}

--- a/Justfile
+++ b/Justfile
@@ -166,7 +166,7 @@ generate_build_constants:
     echo "const BUILD_DATE_STR = \"$(shell date --utc --iso=seconds)\"" >> v/addons/vsk_version/build_constants.gd
     echo "const BUILD_UNIX_TIME = $(shell date +%s)" >> v/addons/vsk_version/build_constants.gd
 
-build-platform-target platform target arch="auto" precision="double" osx_bundle="yes":
+build-platform-target platform target arch="auto" precision="double" osx_bundle="yes" extra_options="":
     #!/usr/bin/env bash
     set -o xtrace
     cd $WORLD_PWD
@@ -194,7 +194,8 @@ build-platform-target platform target arch="auto" precision="double" osx_bundle=
                     osxcross_sdk=darwin24 \
                     generate_bundle={{osx_bundle}} \
                     debug_symbols=yes \
-                    separate_debug_symbols=yes
+                    separate_debug_symbols=yes \
+                    {{extra_options}}
             ;;
         windows)
             scons platform=windows \
@@ -207,7 +208,8 @@ build-platform-target platform target arch="auto" precision="double" osx_bundle=
                 use_llvm=yes \
                 use_mingw=yes \
                 debug_symbols=yes \
-                separate_debug_symbols=yes
+                separate_debug_symbols=yes \
+                {{extra_options}}
             ;;
         android)
             scons platform=android \
@@ -217,6 +219,7 @@ build-platform-target platform target arch="auto" precision="double" osx_bundle=
                     precision={{precision}} \
                     target={{target}} \
                     test=yes \
+                    {{extra_options}} \
                     #debug_symbols=yes    # Editor build runs out of space in Github Runner
             ;;
         linuxbsd)
@@ -228,7 +231,8 @@ build-platform-target platform target arch="auto" precision="double" osx_bundle=
                     target={{target}} \
                     test=yes \
                     debug_symbols=yes \
-                    separate_debug_symbols=yes
+                    separate_debug_symbols=yes \
+                    {{extra_options}}
             ;;
         web)
             scons platform=web \
@@ -239,7 +243,8 @@ build-platform-target platform target arch="auto" precision="double" osx_bundle=
                     target={{target}} \
                     test=yes \
                     dlink_enabled=yes \
-                    debug_symbols=yes
+                    debug_symbols=yes \
+                    {{extra_options}}
             ;;
         ios)
             if [ "$(uname)" = "Darwin" ]; then
@@ -259,7 +264,8 @@ build-platform-target platform target arch="auto" precision="double" osx_bundle=
                     osxcross_sdk=darwin24 \
                     generate_bundle={{osx_bundle}} \
                     debug_symbols=yes \
-                    separate_debug_symbols=yes
+                    separate_debug_symbols=yes \
+                    {{extra_options}}
             ;;
         *)
             echo "Unsupported platform: {{platform}}"


### PR DESCRIPTION
#46 #47
Github runner out of RAM bug was fixed by disabling optimization for web template_debug build.

I recommend leaving extra_options as last argument in future `build-platform-target` updates, to allow options override.