### PR TITLE
Add automated build dispatch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -392,3 +392,23 @@ jobs:
           asset_path: ./v-sekai-godot-${{ matrix.platform }}.zip
           asset_name: v-sekai-godot-${{ matrix.platform }}.zip
           asset_content_type: application/zip
+
+  dispatch:
+    name: Dispatch build message
+    needs: upload-releases
+    env:
+      REPO_TOKEN: ${{ secrets.REPO_DISPATCH }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ['V-Sekai/v-sekai-game']
+    steps:
+      - name: Dispatch to workflow 
+        run: |
+            echo "Send build message to ${{ matrix.repo }}..."
+            curl -v -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${REPO_TOKEN}" \
+            --data '{ "event_type": "build-ready", "client_payload": {} }' \
+            https://api.github.com/repos/${{ matrix.repo }}/dispatches


### PR DESCRIPTION
https://github.com/V-Sekai/v-sekai-game/pull/482
Send automated build message to `v-sekai-game` on `world-godot` commit.

To enable it, add `REPO_DISPATCH` to repository secrets. ~~It should be a generated Github **Classic** Token with all `repo` permissions enabled.~~

Edited:

A fine-grained token with Contents: Read and write permission on v-sekai-game repo should be placed in the REPO_DISPATCH named repository secret of V-Sekai/world-godot.