### PR TITLE
Fix arm64 linux build

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -210,7 +210,10 @@ build-platform-target platform target arch="auto" precision="double" osx_bundle=
     set -o xtrace
     cd $WORLD_PWD
     source "$EMSDK_ROOT/emsdk_env.sh"
-    if [[ "{{arch}}" == "arm64" ]]; then
+    HOST_ARCH=$( uname -m )
+    echo "HOST ARCHITECTURE: ${HOST_ARCH}"
+    if [[ "{{arch}}" == "arm64" && ${HOST_ARCH} == 'x86_64' ]]; then
+        rename 'aarch64-godot-linux-gnu-' '' ${ARM64_ROOT}/bin/*;
         export PATH="$ARM64_ROOT/bin:$PATH";
     fi
     cd godot


### PR DESCRIPTION
https://github.com/V-Sekai/v-sekai-game/issues/483
Gcc arm64 cross compile binaries were not recognized because they had `aarch64-godot-linux-gnu-` prefix.
This issue was fixed.