### PR TITLE
Add upload-templates dependency to dispatch job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -395,7 +395,7 @@ jobs:
 
   dispatch:
     name: Dispatch build message
-    needs: upload-releases
+    needs: [upload-releases, upload-templates]
     env:
       REPO_TOKEN: ${{ secrets.REPO_DISPATCH }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
We should wait for `upload templates` job too before dispatching