### PR TITLE
Add automated nightly pruning

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -401,7 +401,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        repo: ['V-Sekai/v-sekai-game', 'V-Sekai/TOOL_model_explorer']
+        repo: ['V-Sekai/v-sekai-game', 'V-Sekai/TOOL_model_explorer', 'V-Sekai/xr-grid']
     steps:
       - name: Dispatch to workflow 
         run: |

--- a/.github/workflows/nightly-prune.yaml
+++ b/.github/workflows/nightly-prune.yaml
@@ -1,0 +1,49 @@
+name: ♻️ Nightly Cleanup
+on:
+  push:
+    branches:
+    - main
+  workflow_dispatch:
+  schedule:
+    - cron: '00 12 */5 * *'
+  # Runs every 5 days at 12:00
+  # Manual trigger is in Actions Tab > Nightly Cleanup > Run workflow
+
+env:
+  GH_TOKEN: ${{ secrets.REPO_DISPATCH }}
+  ENABLED: 'true'
+  
+  # Keeps only $MAX_NIGHTLY most recent nightly releases.
+  MAX_NIGHTLY: 5
+
+  # Remove associated nightly git tag
+  CLEAR_TAG: 'true'
+jobs:
+  clean:
+    name: Prune nightly releases
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        owner: ['V-Sekai']
+        repo: ['v-sekai-game', 'TOOL_model_explorer', 'xr-grid']
+    steps:
+      - name: Prune
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "Missing token.";
+          elif [ ${ENABLED} == 'true' ]; then
+            echo "Pruning nightly releases...";
+            gh api --paginate repos/${{ matrix.owner }}/${{ matrix.repo }}/releases | \
+            jq -r '[ .[] | select(.tag_name | contains("-nightly-")) ] | sort_by(.published_at) | reverse
+            | .['${MAX_NIGHTLY}':] | .[] | [.id, .tag_name] | @tsv' | \
+            while read -r id tag; do
+                echo "Deleting release id: ${id}, tag: ${tag}";
+                gh api -X DELETE "repos/${{ matrix.owner }}/${{ matrix.repo }}/releases/${id}"
+              if [ ${CLEAR_TAG} == 'true' ]; then
+                echo "Deleting tag: ${tag}";
+                gh api -X DELETE "repos/${{ matrix.owner }}/${{ matrix.repo }}/git/refs/tags/${tag}"
+              fi
+            done;
+          else
+            echo "Scheduled nightly cleanup is disabled.";
+          fi


### PR DESCRIPTION
https://github.com/V-Sekai/v-sekai-game/issues/499

Adds automated pruning of nightly releases in `v-sekai-game`, `TOOL_model_explorer` and `xr-grid`.
Runs on `world-godot` push and every 5 days (Github Action schedule).
Uses already existing **REPO_DISPATCH** token.

This PR also enables automated nightlies in `xr-grid` repository