### PR TITLE
Fix web editor Github build bug

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -196,7 +196,8 @@ jobs:
               ;;  
             web)  
               PLATFORM_ARGS="setup-emscripten"
-              if [ ${{ matrix.target }} == 'template_debug' ]; then
+              if [ ${{ matrix.target }} == 'editor' ] \
+              || [ ${{ matrix.target }} == 'template_debug' ]; then
                   EXTRA_OPTIONS="optimize=none"; # Fix Github runner out of RAM
               fi
               ;;  


### PR DESCRIPTION
#61
Disable optimizations to fix web editor build running out of RAM.
I left them enabled in web template_release only.