### PR TITLE
Fix macos chmod bug in Github Action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -381,7 +381,11 @@ jobs:
       - name: Zip Artifacts
         run: |
           tree
-          chmod +x v-sekai-godot-${{ matrix.platform }}/*editor*
+          if [ "${{ matrix.platform }}" = "macos" ]; then
+            chmod +x v-sekai-godot-${{ matrix.platform }}/*.app/Contents/MacOS/*
+          else
+            chmod +x v-sekai-godot-${{ matrix.platform }}/*editor*
+          fi
           zip -r v-sekai-godot-${{ matrix.platform }}.zip v-sekai-godot-${{ matrix.platform }}
 
       - name: Upload Release Asset


### PR DESCRIPTION
Executable permissions were stripped during artifact upload, see [upload-artifact does not retain artifact permissions](https://www.github.com/actions/upload-artifact/issues/38)

I fixed it by running chmod before zipping